### PR TITLE
Added an optional address field

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -29,10 +29,13 @@ export const verifySignature = async ({
   signature,
 }: RequestBody): Promise<boolean> => {
   try {
-    const signer = secp256k1PublicKeyToBech32Address(
-      data.auth.publicKey,
-      data.auth.chainBech32Prefix
-    )
+    let signer = data.auth.account
+    if(!signer) {
+      signer = secp256k1PublicKeyToBech32Address(
+        data.auth.publicKey,
+        data.auth.chainBech32Prefix
+      )
+    }
     const message = serializeSignDoc(
       makeSignDoc(
         [

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -29,7 +29,7 @@ export const verifySignature = async ({
   signature,
 }: RequestBody): Promise<boolean> => {
   try {
-    let signer = data.auth.account
+    let signer = data.auth.address
     if(!signer) {
       signer = secp256k1PublicKeyToBech32Address(
         data.auth.publicKey,

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export interface Auth {
   chainFeeDenom: string
   chainBech32Prefix: string
   publicKey: string
+  account?: string
 }
 
 export type RequestBody<

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export interface Auth {
   chainFeeDenom: string
   chainBech32Prefix: string
   publicKey: string
-  account?: string
+  address?: string
 }
 
 export type RequestBody<


### PR DESCRIPTION
This PR provides the option for developers to bypass the derivation of the bech32 address from the public key and prefix in the case that the bech32 is incorrectly derived. The address should be considered a fallback if the public key isn't working. I'm not entirely sure why in my case the bech32 wasn't deriving correctly, but when passing the public key with the address override, the signature verification passed. Without the address override, the bech32 on the worker was a different address than on the chain which would create a different signDoc then the one that I signed, invalidating the signature.